### PR TITLE
Enables probability weighting for music tracks

### DIFF
--- a/source/music.lua
+++ b/source/music.lua
@@ -20,16 +20,18 @@ local SONG_SHOULD_LOOP = false
 -- Given a list of {element, weight} pairs, do a weighted random sample
 -- of the elements (returns an index, not the element itself)
 local function weightedRandomChoice(list)
+	if not list or #list == 0 then return nil end
 	if #list == 1 then return list[1][1] end
 	local weight_sum = 0
 	for idx=1,#list do
 		weight_sum = weight_sum + list[idx][2]
 	end
 	local choice = math.random(1, weight_sum)
-	local choice_idx = 1
-	while choice > 0 do
-		choice = choice - list[choice_idx][2]
-		choice_idx = choice_idx + 1
+	for idx=1,#list do
+		choice = choice - list[idx][2]
+		if choice <= 0 then
+			return idx
+		end
 	end
 	return choice_idx
 end
@@ -226,9 +228,9 @@ function music.playNextTrack()
 	local songs = STAGE_TRACKS[STAGE_ID]
 
 	if songs and #songs > 0 then
-		local track = weightedRandomChoice(STAGE_TRACKS)
+		local track = weightedRandomChoice(songs)
 		TRACK_NUMBER[STAGE_ID] = track
-		PLAYING_SONG = songs[track]
+		PLAYING_SONG = songs[track][1]
 
 		if PLAYING_SONG then
 			if STAGE_ID == 0x0 then
@@ -327,7 +329,7 @@ end)
 memory.hook("controller.*.buttons.pressed", "Melee - Music skipper", function(port, pressed)
 	if PANEL_SETTINGS:IsBinding() or PANEL_SETTINGS:IsSlippiReplay() then return end -- Don't skip when the user is setting a button combination or when watching a replay
 	local mask = PANEL_SETTINGS:GetMusicSkipMask()
-	if mask ~= 0x0 and port == love.getPort() and bit.band(pressed, mask) == mask and STAGE_TRACKS[STAGE_ID] and #STAGE_TRACKS[STAGE_ID] > 1 then
+	if mask ~= 0x0 and port == love.getPort() and bit.band(pressed, mask) == mask and STAGE_TRACKS[STAGE_ID][1] and #STAGE_TRACKS[STAGE_ID] > 1 then
 		log.debug("[MUSIC] [MASK = 0x%X] Button combo pressed, stopping music.", mask)
 		music.kill()
 	end


### PR DESCRIPTION
STAGE_TRACKS becomes a table of lists of {source, weight} pairs.
We get the weight from the filename: for example, "Battlefield_20.flac" will have a weight of 20, whereas "Yoshis Story.wav" will have a weight of 1.

#62